### PR TITLE
[Fixes #5] Remove org dependency

### DIFF
--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -5,7 +5,7 @@
 ;; Author: Artem Khramov <futu.fata@gmail.com>
 ;; Created: 6 Jan 2017
 ;; Version: 0.2.2
-;; Package-Requires: ((alert "1.2") (dash "2.13.0") (org "8.0"))
+;; Package-Requires: ((alert "1.2") (dash "2.13.0") (emacs "24.4"))
 ;; Keywords: notification alert org org-agenda agenda
 ;; URL: https://github.com/akhramov/org-wild-notifier.el
 


### PR DESCRIPTION
Since package depends on org, and org is neither on Elpa nor on Melpa,
installation fails (tested on Emacs 25 fresh installation).

Instead of depending on particular org version it makes sense to
depend on an Emacs version.