### PR TITLE
Avoid overwritting `org-agenda-buffer-name`

### DIFF
--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -259,6 +259,7 @@ smoother experience this function also runs a check without timer."
     (let ((org-agenda-use-time-grid nil)
           (org-agenda-compact-blocks t)
           (org-agenda-window-setup 'current-window)
+          (org-agenda-buffer-name nil)
           (org-agenda-buffer-tmp-name org-wild-notifier--agenda-buffer-name))
 
       (org-agenda-list 2)

--- a/tests/org-wild-notifier-tests.el
+++ b/tests/org-wild-notifier-tests.el
@@ -147,3 +147,9 @@ minutes"
   :expected-alerts
   ("Plain event at 16:00 in 10 minutes"
    "IN PROGRESS event at 16:00 in 10 minutes"))
+
+(ert-deftest preserves-agenda-buffer-name ()
+  "Test that org-wild-notifier-check doesn't change `org-agenda-buffer-name`."
+  (let ((old-agenda-buffer-name org-agenda-buffer-name))
+    (org-wild-notifier-check)
+    (should (equal org-agenda-buffer-name old-agenda-buffer-name))))


### PR DESCRIPTION
## Issue
Somehow `org-wild-notifier-check` overwrites `org-agenda-buffer-name` (durably) while doing its process. 
After that, if you create an agenda view, it will be closed by the next call to `org-wild-notifier-check`.

## Fix
By adding `org-agenda-buffer-name` to the `let` statement, it is reassignated to its value at the end of `org-wild-notifier-check`.