### PR TITLE
Also watch for classic timestamps

### DIFF
--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -206,7 +206,7 @@ string, cdr holds time in list-of-integer format."
       (and org-timestamp
            (cons org-timestamp
                  (apply 'encode-time (org-parse-time-string org-timestamp)))))
-    '("DEADLINE" "SCHEDULED"))))
+    '("DEADLINE" "SCHEDULED" "TIMESTAMP"))))
 
 (defun org-wild-notifier--extract-title (marker)
   "Extract event title from MARKER.

--- a/tests/fixtures/planning.org
+++ b/tests/fixtures/planning.org
@@ -7,6 +7,8 @@
    SCHEDULED: <2018-01-04 Wed 16:00>
 ** Plain event at 16:00
    SCHEDULED: <2018-01-04 Wed 16:00>
+** TODO event with raw date at 16:00
+   <2018-01-04 Wed 16:00>
 ** TODO TODO event scheduled on 16:00 with deadline at 17:00
    DEADLINE: <2018-01-04 Thu 17:00> SCHEDULED: <2018-01-04 Thu 16:00>
 ** TODO TODO event at 16:00 with notifications before 80, 60, 55, 43 and 5

--- a/tests/org-wild-notifier-tests.el
+++ b/tests/org-wild-notifier-tests.el
@@ -58,7 +58,8 @@
   "Tests that it notifies before standard notification time (10 minutes)"
   :time "15:50"
   :expected-alerts
-  ("TODO event at 16:00 with NOTIFY_BEFORE property set to 31 in 10 minutes"
+  ("event with raw date at 16:00 in 10 minutes"
+   "TODO event at 16:00 with NOTIFY_BEFORE property set to 31 in 10 minutes"
    "TODO event at 16:00 with notifications before 80, 60, 55, 43 and 5 in \
 10 minutes"
    "TODO event scheduled on 16:00 with deadline at 17:00 in 10 minutes"))
@@ -68,7 +69,8 @@
   :time "14:50"
   :overrides ((org-wild-notifier-alert-time 70))
   :expected-alerts
-  ("TODO event at 16:00 with NOTIFY_BEFORE property set to 31 in \
+  ("event with raw date at 16:00 in 1 hour 10 minutes"
+   "TODO event at 16:00 with NOTIFY_BEFORE property set to 31 in \
 1 hour 10 minutes"
    "TODO event at 16:00 with notifications before 80, 60, 55, 43 and 5 in \
 1 hour 10 minutes"
@@ -114,7 +116,8 @@ events"
   "Tests that whitelist option filters out events."
   :time "15:50"
   :expected-alerts
-  ("TODO event at 16:00 with NOTIFY_BEFORE property set to 31 in 10 minutes"
+  ("event with raw date at 16:00 in 10 minutes"
+   "TODO event at 16:00 with NOTIFY_BEFORE property set to 31 in 10 minutes"
    "TODO event at 16:00 with notifications before 80, 60, 55, 43 and 5 in 10 \
 minutes"
    "TODO event scheduled on 16:00 with deadline at 17:00 in 10 minutes"))
@@ -124,7 +127,8 @@ minutes"
   :time "15:50"
   :overrides ((org-wild-notifier-keyword-whitelist nil))
   :expected-alerts
-  ("TODO event at 16:00 with NOTIFY_BEFORE property set to 31 in 10 minutes"
+  ("event with raw date at 16:00 in 10 minutes"
+   "TODO event at 16:00 with NOTIFY_BEFORE property set to 31 in 10 minutes"
    "TODO event at 16:00 with notifications before 80, 60, 55, 43 and 5 in 10 minutes"
    "TODO event scheduled on 16:00 with deadline at 17:00 in 10 minutes"
    "Plain event at 16:00 in 10 minutes"


### PR DESCRIPTION
Follow #7 

Now classic timestamps (e.g. `<2018-02-21 Tue 20:52>`) are also watched by org-wild-notifier.

