### PR TITLE
[Fixes #13] Incorrect agenda is returned by org-agenda-list

### DIFF
--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -265,7 +265,7 @@ smoother experience this function also runs a check without timer."
               (org-agenda-buffer-tmp-name org-wild-notifier--agenda-buffer-name)
               (already-opened org-agenda-new-buffers))
 
-          (org-agenda-list 2)
+          (org-agenda-list 2 (org-read-date nil nil "today"))
 
           (-each
             (->> (org-wild-notifier--retrieve-events)


### PR DESCRIPTION
org-agenda-list doesn't return consecutive days on newer orgmode
versions anymore.

This change manually sets starting day for org-agenda-list