### PR TITLE
Non-existent files fix (#23) and straight.el support (#21)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 # Taken from here:
 # https://github.com/alphapapa/helm-org-rifle/blob/94cb602d6373229c88126a5888f03f4b538f0771/.travis.yml
+matrix:
+  allow_failures:
+    env: EVM_EMACS=emacs-git-snapshot-travis
+
 addons:
   apt:
     packages:
@@ -22,9 +26,9 @@ before_install:
 
 env:
   - EVM_EMACS=emacs-24.4-travis
-  - EVM_EMACS=emacs-24.5-travis
-  - EVM_EMACS=emacs-25.1-travis
   - EVM_EMACS=emacs-25.2-travis
+  - EVM_EMACS=emacs-26.2-travis
+  - EVM_EMACS=emacs-git-snapshot-travis
 script:
   - ln -s tests/fixtures/ fixtures
   - cask exec emacs --batch -l ert -l org-wild-notifier.el -l tests/org-wild-notifier-tests.el  -l org-wild-notifier.el -f ert-run-tests-batch-and-exit

--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -208,14 +208,14 @@ Returns a list of notification messages"
 
 (defun org-wild-notifier--apply-whitelist (markers)
   "Apply whitelist to MARKERS."
-  (if-let ((whitelist-predicates (org-wild-notifier--whitelist-predicates)))
+  (-if-let (whitelist-predicates (org-wild-notifier--whitelist-predicates))
       (-> (apply '-orfn whitelist-predicates)
           (-filter markers))
     markers))
 
 (defun org-wild-notifier--apply-blacklist (markers)
   "Apply blacklist to MARKERS."
-  (if-let ((blacklist-predicates (org-wild-notifier--blacklist-predicates)))
+  (-if-let (blacklist-predicates (org-wild-notifier--blacklist-predicates))
       (-> (apply '-orfn blacklist-predicates)
           (-remove markers))
     markers))
@@ -223,14 +223,18 @@ Returns a list of notification messages"
 (defun org-wild-notifier--retrieve-events ()
   "Get events from agenda view."
   (async-sandbox
-   (let ((agenda-files org-agenda-files))
+   (let ((agenda-files (-filter 'file-exists-p org-agenda-files))
+         ;; Some package managers manipulate `load-path` variable.
+         (my-load-path load-path))
      (lambda ()
        (let ((org-agenda-use-time-grid nil)
              (org-agenda-compact-blocks t))
+         (setf org-agenda-files agenda-files)
+         (setf load-path my-load-path)
+
          (package-initialize)
          (require 'org-wild-notifier)
 
-         (setf org-agenda-files agenda-files)
          (org-agenda-list 2
                           (org-read-date nil nil "today"))
 

--- a/tests/org-wild-notifier-tests.el
+++ b/tests/org-wild-notifier-tests.el
@@ -193,3 +193,8 @@ minutes"
               (org-wild-notifier-tags-blacklist '("foo")))
   :expected-alerts
   ("event with raw date at 16:00 in 10 minutes"))
+
+(org-wild-notifier-test non-existent-fixture
+  "Tests that it doesn't hang if there's a non-existent agenda file."
+  :fixture "bad.org"
+  :expected-alerts ())


### PR DESCRIPTION
[#23] If agenda files are missing for some reason, org-mode presents
user an interactive choice whether to delete those files or not. Since
we're running agenda in an async process.. Well, Emacs just hangs.
[#21] straight.el modifies load path and therefore we cannot load any
of packages in forked emacs process...

This change
* [#23] filters-out non-existent agenda files
* [#21] injects load-path variable to forked emacs env.
* Fixes build for emacs 24 & 25.