### PR TITLE
[#25] Emacs lags when check runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ before_install:
 
 env:
   - EVM_EMACS=emacs-24.4-travis
-  - EVM_EMACS=emacs-25.2-travis
-  - EVM_EMACS=emacs-26.2-travis
-  - EVM_EMACS=emacs-git-snapshot-travis
+  - EVM_EMACS=emacs-25.3-travis
+  - EVM_EMACS=emacs-26.3-travis-linux-xenial
+  - EVM_EMACS=emacs-git-snapshot-travis-linux-xenial
 script:
   - ln -s tests/fixtures/ fixtures
   - cask exec emacs --batch -l ert -l org-wild-notifier.el -l tests/org-wild-notifier-tests.el  -l org-wild-notifier.el -f ert-run-tests-batch-and-exit

--- a/tests/org-wild-notifier-tests.el
+++ b/tests/org-wild-notifier-tests.el
@@ -29,8 +29,9 @@
 (require 'dash)
 (require 'subr-x)
 
-(defmacro async-sandbox (fn)
-  `(funcall ,fn))
+(defun async-start (fn callback)
+  (->> (funcall fn)
+       (funcall callback)))
 
 (cl-defmacro org-wild-notifier-test
     (test-name desc


### PR DESCRIPTION
`org-wild-notifier-check` causes a lag. The issue originates in
`async` library, namely, `async-sandbox` blocking the main thread

This change
* modifies `org-wild-notifier-check` function to opt
  `async-sandbox` out in favor of `async-start` + callback.
* fixes the travis build & bumps emacs CI versions