### PR TITLE
[#32] Multiple alert times for all entries

### DIFF
--- a/README.org
+++ b/README.org
@@ -24,7 +24,7 @@ Oh, yes. This package provides some configuration options:
 
 | Description                                                                                     | Variable                               | Default value               |
 |-------------------------------------------------------------------------------------------------+----------------------------------------+-----------------------------|
-| Alert time in minutes                                                                           | org-wild-notifier-alert-time           | 10                          |
+| Alert time in minutes                                                                           | org-wild-notifier-alert-time           | '(10)                       |
 | Title of notifications                                                                          | org-wild-notifier-notification-title   | Agenda                      |
 | Org keyword based whitelist. You'll get notified /only/ about events specified by this variable | org-wild-notifier-keyword-whitelist    | '("TODO")                   |
 | Org keyword based blacklist. You'll /never/ be notified about events specified by this variable | org-wild-notifier-keyword-blacklist    | nil                         |

--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -55,12 +55,13 @@
   "org-wild-notifier customization options"
   :group 'org)
 
-(defcustom org-wild-notifier-alert-time 10
+(defcustom org-wild-notifier-alert-time '(10)
   "Time in minutes to get a notification about upcomming event.
 Cannot be less than 1."
   :package-version '(org-wild-notifier . "0.1.0")
   :group 'org-wild-notifier
-  :type 'integer)
+  :type '(choice (integer :tag "Notify once")
+                 (repeat integer)))
 
 (defcustom org-wild-notifier-alert-times-property "WILD_NOTIFIER_NOTIFY_BEFORE"
   "Use this property in your agenda files to add additional notifications \
@@ -283,7 +284,7 @@ MARKER acts like the event's identifier."
   "Extract notification intervals from the event's properties.
 MARKER acts like the event's identifier.  Resulting list also contains
 standard notification interval (`org-wild-notifier-alert-time')."
-  `(,org-wild-notifier-alert-time
+  `(,@(-flatten (list org-wild-notifier-alert-time))
     ,@(-map 'string-to-number
            (org-entry-get-multivalued-property
             marker

--- a/tests/org-wild-notifier-tests.el
+++ b/tests/org-wild-notifier-tests.el
@@ -82,6 +82,20 @@
    "TODO event scheduled on 16:00 with deadline at 17:00 in \
 1 hour 10 minutes"))
 
+(org-wild-notifier-test alert-time-overriden-with-list
+  "Test that standard alert time can be customized & set to list"
+  :time "14:50"
+  :overrides ((org-wild-notifier-alert-time '(10 70)))
+  :expected-alerts
+  ("event with raw date at 16:00 in 1 hour 10 minutes"
+   "TODO event at 16:00 with NOTIFY_BEFORE property set to 31 in \
+1 hour 10 minutes"
+   "TODO event at 16:00 with notifications before 80, 60, 55, 43 and 5 in \
+1 hour 10 minutes"
+   "TODO event scheduled on 16:00 with deadline at 17:00 in \
+1 hour 10 minutes"
+   "TODO event at 15:00 in 10 minutes"))
+
 (org-wild-notifier-test notification-property
   "Tests that notifier takes in account the notification property"
   :time "15:17"


### PR DESCRIPTION
As for now, org-wild-notifier notifies just once, if
WILD_NOTIFIER_NOTIFY_BEFORE property is not set. If user wants to be
notified of all events multiple times, they'd have to set the property
on the every single agenda entry, which is inconvenient.

This change tweaks `org-wild-notifier-alert-time` custom variable to
support array values, which effectively gives the semantic described
above.