### PR TITLE
[#37] Events without keywords

### DIFF
--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -233,12 +233,22 @@ Returns a list of notification messages"
   "Get events from agenda view."
   (let ((agenda-files (-filter 'file-exists-p org-agenda-files))
         ;; Some package managers manipulate `load-path` variable.
-        (my-load-path load-path))
+        (my-load-path load-path)
+        (alert-time org-wild-notifier-alert-time)
+        (keyword-whitelist org-wild-notifier-keyword-whitelist)
+        (keyword-blacklist org-wild-notifier-keyword-blacklist)
+        (tags-whitelist org-wild-notifier-tags-whitelist)
+        (tags-blacklist org-wild-notifier-tags-blacklist))
     (lambda ()
       (let ((org-agenda-use-time-grid nil)
             (org-agenda-compact-blocks t))
         (setf org-agenda-files agenda-files)
         (setf load-path my-load-path)
+        (setf org-wild-notifier-alert-time alert-time)
+        (setf org-wild-notifier-keyword-whitelist keyword-whitelist)
+        (setf org-wild-notifier-keyword-blacklist keyword-blacklist)
+        (setf org-wild-notifier-tags-whitelist tags-whitelist)
+        (setf org-wild-notifier-tags-blacklist tags-blacklist)
 
         (package-initialize)
         (require 'org-wild-notifier)

--- a/tests/fixtures/planning.org
+++ b/tests/fixtures/planning.org
@@ -11,6 +11,8 @@
    SCHEDULED: <2018-01-04 Wed 16:00>
 ** TODO event with raw date at 16:00                                    :baz:
    <2018-01-04 Wed 16:00>
+** event without a keyword at 19:35
+   <2018-01-04 Wed 19:35>
 ** TODO TODO event scheduled on 16:00 with deadline at 17:00
    DEADLINE: <2018-01-04 Thu 17:00> SCHEDULED: <2018-01-04 Thu 16:00>
 ** TODO TODO event at 16:00 with notifications before 80, 60, 55, 43 and 5

--- a/tests/org-wild-notifier-tests.el
+++ b/tests/org-wild-notifier-tests.el
@@ -209,6 +209,13 @@ minutes"
   :expected-alerts
   ("event with raw date at 16:00 in 10 minutes"))
 
+(org-wild-notifier-test event-without-a-keyword
+  "Tests that blacklist option filters out events."
+  :time "19:25"
+  :overrides ((org-wild-notifier-keyword-whitelist '()))
+  :expected-alerts
+  ("event without a keyword at 19:35 in 10 minutes"))
+
 (org-wild-notifier-test non-existent-fixture
   "Tests that it doesn't hang if there's a non-existent agenda file."
   :fixture "bad.org"


### PR DESCRIPTION
It was reported that alerts for keyword-less events won't fire even if
the keywords whitelist is nil. This happens because custom variables
overrides won't load in the async process, if variables were not set
via customize.

This change sets all relevant custom variables within the async
process context.