### PR TITLE
Change default message for 0 seconds left

### DIFF
--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -165,7 +165,7 @@ Returns a list of notification intervals."
   "Human-friendly representation for SECONDS."
   (-> seconds
        (pcase
-         ((pred (>= 0)) "today")
+         ((pred (>= 0)) "right now")
          ((pred (>= 3600)) "in %M")
          (_ "in %H %M"))
 


### PR DESCRIPTION
First of all, thanks for this amazing library! It has made my experience with Spacemacs a very good one 🚀 

After saying this, I think `right now` is  a little more descriptive than `today`.

For example let's take a reminder for `Important call with boss`. It would look something like this:

```
* TODO Important call with boss
   SCHEDULED: <2020-11-09 Mon 13:45>
   :PROPERTIES:
     :WILD_NOTIFIER_NOTIFY_BEFORE: 5 0
   :END:
```
The notifications would look something like the following:

 `Important call with boss in 10 min`
 `Important call with boss in 5 min`
 `Important call with boss today` <- This looks really weird for me
 `Important call with boss right now` <- This would look much better for me

The good thing of this PR is that if you use this library to remind you about your event at a specific time, you will see `Your event right now` and not `Your event today`. 

The caveats of this could be the scheduled events with no time defined, as it takes 00:00 (as far as I know) and it would be weird to see `Your event right now` at midnight.

Thanks again!