### PR TITLE
Use org-agenda-files function to read agenda files list

### DIFF
--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -230,7 +230,7 @@ Returns a list of notification messages"
 
 (defun org-wild-notifier--retrieve-events ()
   "Get events from agenda view."
-  (let ((agenda-files (-filter 'file-exists-p org-agenda-files))
+  (let ((agenda-files (-filter 'file-exists-p (org-agenda-files)))
         ;; Some package managers manipulate `load-path` variable.
         (my-load-path load-path)
         (alert-time org-wild-notifier-alert-time)


### PR DESCRIPTION
The variable org-agenda-files may be set to a string, which is used as
a file name.  That file is read, and each line in the file is used as
an agenda file.