### PR TITLE
Add option to select which timestamps actually send a notification

### DIFF
--- a/README.org
+++ b/README.org
@@ -22,15 +22,16 @@ be unobtrusive in use and configuration.
 
 Oh, yes. This package provides some configuration options:
 
-| Description                                                                                     | Variable                               | Default value               |
-|-------------------------------------------------------------------------------------------------+----------------------------------------+-----------------------------|
-| Alert time in minutes                                                                           | org-wild-notifier-alert-time           | '(10)                       |
-| Title of notifications                                                                          | org-wild-notifier-notification-title   | Agenda                      |
-| Org keyword based whitelist. You'll get notified /only/ about events specified by this variable | org-wild-notifier-keyword-whitelist    | '("TODO")                   |
-| Org keyword based blacklist. You'll /never/ be notified about events specified by this variable | org-wild-notifier-keyword-blacklist    | nil                         |
-| Org tags based whitelist. You'll get notified /only/ about events specified by this variable    | org-wild-notifier-tags-whitelist       | nil                         |
-| Org tags based blacklist. You'll /never/ be notified about events specified by this variable    | org-wild-notifier-tags-blacklist       | nil                         |
-| Property which adds additional notifications                                                    | org-wild-notifier-alert-times-property | WILD_NOTIFIER_NOTIFY_BEFORE |
+| Description                                                                                       | Variable                               | Default value                         |
+|---------------------------------------------------------------------------------------------------+----------------------------------------+---------------------------------------|
+| Alert time in minutes                                                                             | org-wild-notifier-alert-time           | '(10)                                 |
+| Title of notifications                                                                            | org-wild-notifier-notification-title   | Agenda                                |
+| Org keyword based whitelist. You'll get notified /only/ about events specified by this variable   | org-wild-notifier-keyword-whitelist    | '("TODO")                             |
+| Org keyword based blacklist. You'll /never/ be notified about events specified by this variable   | org-wild-notifier-keyword-blacklist    | nil                                   |
+| Org tags based whitelist. You'll get notified /only/ about events specified by this variable      | org-wild-notifier-tags-whitelist       | nil                                   |
+| Org tags based blacklist. You'll /never/ be notified about events specified by this variable      | org-wild-notifier-tags-blacklist       | nil                                   |
+| Org timestamp based whitelist. You'll get notified /only/ about events specified by this variable | org-wild-notifier-entries              | '("DEADLINE" "SCHEDULED" "TIMESTAMP") |
+| Property which adds additional notifications                                                      | org-wild-notifier-alert-times-property | WILD_NOTIFIER_NOTIFY_BEFORE           |
 
 
 The last property demands further explanations.

--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -101,6 +101,12 @@ Leave this variable blank if you do not want to filter anything."
   :group 'org-wild-notifier
   :type '(repeat string))
 
+(defcustom org-wild-notifier-entries '("DEADLINE" "SCHEDULED" "TIMESTAMP")
+  "Receive notifications from this timestamp entries"
+  :package-version '(org-wild-notifier . "0.3.1")
+  :group 'org-wild-notifier
+  :type '(repeat string))
+
 (defcustom org-wild-notifier--alert-severity 'medium
   "Severity of the alert.
 options: 'high 'medium 'low"
@@ -279,7 +285,7 @@ string, cdr holds time in list-of-integer format."
       (and org-timestamp
            (cons org-timestamp
                  (apply 'encode-time (org-parse-time-string org-timestamp)))))
-    '("DEADLINE" "SCHEDULED" "TIMESTAMP"))))
+    org-wild-notifier-entries)))
 
 (defun org-wild-notifier--extract-title (marker)
   "Extract event title from MARKER.


### PR DESCRIPTION
I've added a new variable org-wild-notifier-entries to select which timestamps (any combination of DEADLINE, SCHEDULED, TIMESTAMP) trigger a notification