### PR TITLE
Showing absolute time in message

### DIFF
--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -176,18 +176,18 @@ Returns a list of notification intervals."
       (substring time-string 16 21)
       "00:00"))
 
-(defun org-wild-notifier--notification-text (interval event)
-  "For given INTERVAL and EVENT get notification wording."
+(defun org-wild-notifier--notification-text (str-interval event)
+  "For given STR-INTERVAL list and EVENT get notification wording."
   (format "%s at %s (%s)"
           (cdr (assoc 'title event))
-          (org-wild-notifier--get-hh-mm-from-org-time-string
-           (car (car (cadr (assoc 'times event)))))
-          (org-wild-notifier--time-left (* 60 interval))))
+          (org-wild-notifier--get-hh-mm-from-org-time-string (car str-interval))
+          (org-wild-notifier--time-left (* 60 (cdr str-interval)))))
 
 (defun org-wild-notifier--check-event (event)
   "Get notifications for given EVENT.
 Returns a list of notification messages"
   (->> (org-wild-notifier--notifications event)
+       (--zip-with (cons (car it) other) (cadr (assoc 'times event)))
        (--map (org-wild-notifier--notification-text it event))))
 
 (defun org-wild-notifier--get-tags (marker)

--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -164,7 +164,7 @@ Returns a list of notification intervals."
   "Human-friendly representation for SECONDS."
   (-> seconds
        (pcase
-         ((pred (>= 0)) "today")
+         ((pred (>= 0)) "right now")
          ((pred (>= 3600)) "in %M")
          (_ "in %H %M"))
 

--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -170,10 +170,18 @@ Returns a list of notification intervals."
 
        (format-seconds seconds)))
 
+(defun org-wild-notifier--get-hh-mm-from-org-time-string (time-string)
+  "Convert given org time-string TIME-STRING into string with 'hh:mm' format."
+  (if (>= (length time-string) 22)
+      (substring time-string 16 21)
+      "00:00"))
+
 (defun org-wild-notifier--notification-text (interval event)
   "For given INTERVAL and EVENT get notification wording."
-  (format "%s %s"
+  (format "%s at %s (%s)"
           (cdr (assoc 'title event))
+          (org-wild-notifier--get-hh-mm-from-org-time-string
+           (car (car (cadr (assoc 'times event)))))
           (org-wild-notifier--time-left (* 60 interval))))
 
 (defun org-wild-notifier--check-event (event)

--- a/tests/org-wild-notifier-tests.el
+++ b/tests/org-wild-notifier-tests.el
@@ -123,7 +123,7 @@ events"
   :time "14:59"
   :overrides ((org-wild-notifier--day-wide-events t))
   :expected-alerts
-  ("TODO event scheduled on today today"))
+  ("TODO event scheduled on today right now"))
 
 (org-wild-notifier-test next-day-events
   "Tests that user receives notifications on next day events"

--- a/tests/org-wild-notifier-tests.el
+++ b/tests/org-wild-notifier-tests.el
@@ -63,59 +63,59 @@
   "Tests that it notifies before standard notification time (10 minutes)"
   :time "15:50"
   :expected-alerts
-  ("event with raw date at 16:00 in 10 minutes"
-   "TODO event at 16:00 with NOTIFY_BEFORE property set to 31 in 10 minutes"
-   "TODO event at 16:00 with notifications before 80, 60, 55, 43 and 5 in \
-10 minutes"
-   "TODO event scheduled on 16:00 with deadline at 17:00 in 10 minutes"))
+  ("event with raw date at 16:00 at 16:00 (in 10 minutes)"
+   "TODO event at 16:00 with NOTIFY_BEFORE property set to 31 at 16:00 (in 10 minutes)"
+   "TODO event at 16:00 with notifications before 80, 60, 55, 43 and 5 at 16:00 (in \
+10 minutes)"
+   "TODO event scheduled on 16:00 with deadline at 17:00 at 16:00 (in 10 minutes)"))
 
 (org-wild-notifier-test alert-time-overriden
   "Test that standard alert time can be customized"
   :time "14:50"
   :overrides ((org-wild-notifier-alert-time 70))
   :expected-alerts
-  ("event with raw date at 16:00 in 1 hour 10 minutes"
-   "TODO event at 16:00 with NOTIFY_BEFORE property set to 31 in \
-1 hour 10 minutes"
-   "TODO event at 16:00 with notifications before 80, 60, 55, 43 and 5 in \
-1 hour 10 minutes"
-   "TODO event scheduled on 16:00 with deadline at 17:00 in \
-1 hour 10 minutes"))
+  ("event with raw date at 16:00 at 16:00 (in 1 hour 10 minutes)"
+   "TODO event at 16:00 with NOTIFY_BEFORE property set to 31 at 16:00 (in \
+1 hour 10 minutes)"
+   "TODO event at 16:00 with notifications before 80, 60, 55, 43 and 5 at 16:00 (in \
+1 hour 10 minutes)"
+   "TODO event scheduled on 16:00 with deadline at 17:00 at 16:00 (in \
+1 hour 10 minutes)"))
 
 (org-wild-notifier-test alert-time-overriden-with-list
   "Test that standard alert time can be customized & set to list"
   :time "14:50"
   :overrides ((org-wild-notifier-alert-time '(10 70)))
   :expected-alerts
-  ("event with raw date at 16:00 in 1 hour 10 minutes"
-   "TODO event at 16:00 with NOTIFY_BEFORE property set to 31 in \
-1 hour 10 minutes"
-   "TODO event at 16:00 with notifications before 80, 60, 55, 43 and 5 in \
-1 hour 10 minutes"
-   "TODO event scheduled on 16:00 with deadline at 17:00 in \
-1 hour 10 minutes"
-   "TODO event at 15:00 in 10 minutes"))
+  ("event with raw date at 16:00 at 16:00 (in 1 hour 10 minutes)"
+   "TODO event at 16:00 with NOTIFY_BEFORE property set to 31 at 16:00 (in \
+1 hour 10 minutes)"
+   "TODO event at 16:00 with notifications before 80, 60, 55, 43 and 5 at 16:00 (in \
+1 hour 10 minutes)"
+   "TODO event scheduled on 16:00 with deadline at 17:00 at 16:00 (in \
+1 hour 10 minutes)"
+   "TODO event at 15:00 at 15:00 (in 10 minutes)"))
 
 (org-wild-notifier-test notification-property
   "Tests that notifier takes in account the notification property"
   :time "15:17"
   :expected-alerts
   ("TODO event at 16:00 with notifications before \
-80, 60, 55, 43 and 5 in 43 minutes"))
+80, 60, 55, 43 and 5 at 16:00 (in 43 minutes)"))
 
 (org-wild-notifier-test notification-property-overriden
   "Tests that it is possible to customize the notification property"
   :time "15:29"
   :overrides ((org-wild-notifier-alert-times-property "NOTIFY_BEFORE"))
   :expected-alerts
-  ("TODO event at 16:00 with NOTIFY_BEFORE property set to 31 in 31 minutes"))
+  ("TODO event at 16:00 with NOTIFY_BEFORE property set to 31 at 16:00 (in 31 minutes)"))
 
 (org-wild-notifier-test message-within-one-minute
   "Tests that message is correct"
   :time "14:59"
   :overrides ((org-wild-notifier-alert-time 1))
   :expected-alerts
-  ("TODO event at 15:00 in 1 minute"))
+  ("TODO event at 15:00 at 15:00 (in 1 minute)"))
 
 (org-wild-notifier-test day-wide-events
   "Tests that user receives notifications on day-wide (w/o specified time) \
@@ -123,45 +123,45 @@ events"
   :time "14:59"
   :overrides ((org-wild-notifier--day-wide-events t))
   :expected-alerts
-  ("TODO event scheduled on today right now"))
+  ("TODO event scheduled on today at 00:00 (right now)"))
 
 (org-wild-notifier-test next-day-events
   "Tests that user receives notifications on next day events"
   :time "23:50"
   :expected-alerts
-  ("TODO event scheduled on tomorrow in 10 minutes"))
+  ("TODO event scheduled on tomorrow at 00:00 (in 10 minutes)"))
 
 (org-wild-notifier-test keyword-whitelist
   "Tests that whitelist option filters out events."
   :time "15:50"
   :expected-alerts
-  ("event with raw date at 16:00 in 10 minutes"
-   "TODO event at 16:00 with NOTIFY_BEFORE property set to 31 in 10 minutes"
-   "TODO event at 16:00 with notifications before 80, 60, 55, 43 and 5 in 10 \
-minutes"
-   "TODO event scheduled on 16:00 with deadline at 17:00 in 10 minutes"))
+  ("event with raw date at 16:00 at 16:00 (in 10 minutes)"
+   "TODO event at 16:00 with NOTIFY_BEFORE property set to 31 at 16:00 (in 10 minutes)"
+   "TODO event at 16:00 with notifications before 80, 60, 55, 43 and 5 at 16:00 (in 10 \
+minutes)"
+   "TODO event scheduled on 16:00 with deadline at 17:00 at 16:00 (in 10 minutes)"))
 
 (org-wild-notifier-test keyword-whitelist-disabled
   "Tests that whitelist option can be disabled"
   :time "15:50"
   :overrides ((org-wild-notifier-keyword-whitelist nil))
   :expected-alerts
-  ("event with raw date at 16:00 in 10 minutes"
-   "TODO event at 16:00 with NOTIFY_BEFORE property set to 31 in 10 minutes"
-   "TODO event at 16:00 with notifications before 80, 60, 55, 43 and 5 in 10 minutes"
-   "TODO event scheduled on 16:00 with deadline at 17:00 in 10 minutes"
-   "Tagged event at 16:00 in 10 minutes"
-   "Plain event at 16:00 in 10 minutes"
-   "IN PROGRESS event at 16:00 in 10 minutes"
-   "DONE event at 16:00 in 10 minutes"))
+  ("event with raw date at 16:00 at 16:00 (in 10 minutes)"
+   "TODO event at 16:00 with NOTIFY_BEFORE property set to 31 at 16:00 (in 10 minutes)"
+   "TODO event at 16:00 with notifications before 80, 60, 55, 43 and 5 at 16:00 (in 10 minutes)"
+   "TODO event scheduled on 16:00 with deadline at 17:00 at 16:00 (in 10 minutes)"
+   "Tagged event at 16:00 at 16:00 (in 10 minutes)"
+   "Plain event at 16:00 at 16:00 (in 10 minutes)"
+   "IN PROGRESS event at 16:00 at 16:00 (in 10 minutes)"
+   "DONE event at 16:00 at 16:00 (in 10 minutes)"))
 
 (org-wild-notifier-test keyword-whitelist-with-two-items
   "Tests that whitelist option can contain more than one items"
   :time "15:50"
   :overrides ((org-wild-notifier-keyword-whitelist '("IN PROGRESS" "DONE")))
   :expected-alerts
-  ("IN PROGRESS event at 16:00 in 10 minutes"
-   "DONE event at 16:00 in 10 minutes"))
+  ("IN PROGRESS event at 16:00 at 16:00 (in 10 minutes)"
+   "DONE event at 16:00 at 16:00 (in 10 minutes)"))
 
 (org-wild-notifier-test keyword-blacklist
   "Tests that blacklist option filters out events."
@@ -169,9 +169,9 @@ minutes"
   :overrides ((org-wild-notifier-keyword-whitelist '())
               (org-wild-notifier-keyword-blacklist '("TODO" "DONE")))
   :expected-alerts
-  ("Tagged event at 16:00 in 10 minutes"
-   "Plain event at 16:00 in 10 minutes"
-   "IN PROGRESS event at 16:00 in 10 minutes"))
+  ("Tagged event at 16:00 at 16:00 (in 10 minutes)"
+   "Plain event at 16:00 at 16:00 (in 10 minutes)"
+   "IN PROGRESS event at 16:00 at 16:00 (in 10 minutes)"))
 
 (org-wild-notifier-test tags-whitelist
   "Tests that whitelist option filters out events."
@@ -179,7 +179,7 @@ minutes"
   :overrides ((org-wild-notifier-tags-whitelist '("bar"))
               (org-wild-notifier-keyword-whitelist '()))
   :expected-alerts
-  ("Tagged event at 16:00 in 10 minutes"))
+  ("Tagged event at 16:00 at 16:00 (in 10 minutes)"))
 
 (org-wild-notifier-test two-tags-whitelist
   "Tests that whitelist option filters out events."
@@ -187,8 +187,8 @@ minutes"
   :overrides ((org-wild-notifier-tags-whitelist '("bar" "baz"))
               (org-wild-notifier-keyword-whitelist '()))
   :expected-alerts
-  ("event with raw date at 16:00 in 10 minutes"
-   "Tagged event at 16:00 in 10 minutes"))
+  ("event with raw date at 16:00 at 16:00 (in 10 minutes)"
+   "Tagged event at 16:00 at 16:00 (in 10 minutes)"))
 
 (org-wild-notifier-test mixed-whitelist
   "Tests that whitelist option filters out events."
@@ -196,9 +196,9 @@ minutes"
   :overrides ((org-wild-notifier-tags-whitelist '("bar" "baz"))
               (org-wild-notifier-keyword-whitelist '("IN PROGRESS")))
   :expected-alerts
-  ("event with raw date at 16:00 in 10 minutes"
-   "Tagged event at 16:00 in 10 minutes"
-   "IN PROGRESS event at 16:00 in 10 minutes"))
+  ("event with raw date at 16:00 at 16:00 (in 10 minutes)"
+   "Tagged event at 16:00 at 16:00 (in 10 minutes)"
+   "IN PROGRESS event at 16:00 at 16:00 (in 10 minutes)"))
 
 (org-wild-notifier-test mixed-tags-whitelist-blacklist
   "Tests that blacklist option filters out events."
@@ -207,14 +207,14 @@ minutes"
               (org-wild-notifier-tags-whitelist '("baz"))
               (org-wild-notifier-tags-blacklist '("foo")))
   :expected-alerts
-  ("event with raw date at 16:00 in 10 minutes"))
+  ("event with raw date at 16:00 at 16:00 (in 10 minutes)"))
 
 (org-wild-notifier-test event-without-a-keyword
   "Tests that blacklist option filters out events."
   :time "19:25"
   :overrides ((org-wild-notifier-keyword-whitelist '()))
   :expected-alerts
-  ("event without a keyword at 19:35 in 10 minutes"))
+  ("event without a keyword at 19:35 at 19:35 (in 10 minutes)"))
 
 (org-wild-notifier-test non-existent-fixture
   "Tests that it doesn't hang if there's a non-existent agenda file."


### PR DESCRIPTION
I've stumbled upon this package quite recently and this was exactly what I needed. Thanks for the nice package!

There were a few things that I thought could be improved, and showing the absolute event time in the notification (in HH:MM format) was one of them, as already pointed out in #43, so I modified the message body accordingly. Since I was making changes to the message text anyway, I included the changes in #42 too. I also made adjustments to the test cases to incorporate these changes.

Hope this helps!