### PR TITLE
Fix type error in white-/blacklist functions

### DIFF
--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -193,9 +193,9 @@ Returns a list of notification messages"
        (--zip-with (cons (car it) other) (cadr (assoc 'times event)))
        (--map (org-wild-notifier--notification-text it event))))
 
-(defun org-wild-notifier--get-tags (marker)
-  "Retrieve tags of MARKER."
-  (-> (org-entry-get marker "TAGS")
+(defun org-wild-notifier--get-tags (event)
+  "Retrieve tags of EVENT."
+  (-> (assoc "ALLTAGS" event)
       (or "")
       (org-split-string  ":")))
 
@@ -203,7 +203,7 @@ Returns a list of notification messages"
   (->> `([,org-wild-notifier-keyword-whitelist
           (lambda (it)
             (-contains-p org-wild-notifier-keyword-whitelist
-                         (org-entry-get it "TODO")))]
+                         (assoc "TODO" it)))]
 
          [,org-wild-notifier-tags-whitelist
           (lambda (it)
@@ -216,7 +216,7 @@ Returns a list of notification messages"
   (->> `([,org-wild-notifier-keyword-blacklist
           (lambda (it)
             (-contains-p org-wild-notifier-keyword-blacklist
-                         (org-entry-get it "TODO")))]
+                         (assoc "TODO" it)))]
 
          [,org-wild-notifier-tags-blacklist
           (lambda (it)
@@ -225,19 +225,19 @@ Returns a list of notification messages"
        (--filter (aref it 0))
        (--map (aref it 1))))
 
-(defun org-wild-notifier--apply-whitelist (markers)
-  "Apply whitelist to MARKERS."
+(defun org-wild-notifier--apply-whitelist (events)
+  "Apply whitelist to EVENTS."
   (-if-let (whitelist-predicates (org-wild-notifier--whitelist-predicates))
       (-> (apply '-orfn whitelist-predicates)
-          (-filter markers))
-    markers))
+          (-filter events))
+    events))
 
-(defun org-wild-notifier--apply-blacklist (markers)
-  "Apply blacklist to MARKERS."
+(defun org-wild-notifier--apply-blacklist (events)
+  "Apply blacklist to EVENTS."
   (-if-let (blacklist-predicates (org-wild-notifier--blacklist-predicates))
       (-> (apply '-orfn blacklist-predicates)
-          (-remove markers))
-    markers))
+          (-remove events))
+    events))
 
 (defun org-wild-notifier--retrieve-events ()
   "Get events from agenda view."
@@ -296,8 +296,7 @@ string, cdr holds time in list-of-integer format."
     '("DEADLINE" "SCHEDULED" "TIMESTAMP"))))
 
 (defun org-wild-notifier--extract-title (event)
-  "Extract event title from EVENT.
-MARKER acts like the event's identifier."
+  "Extract event title from EVENT."
   (cdr (assoc "ITEM" event)))
 
 (defun org-wild-notifier--extract-notication-intervals (event)


### PR DESCRIPTION
The events are now passed around as alists and not markers, so we needed to update how we access entry properties.

This fixes #59.