### PR TITLE
Re-add the org-wild-notifier--time= function

### DIFF
--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -130,6 +130,16 @@ options: 'high 'medium 'low"
 (defvar org-wild-notifier--last-check-time (seconds-to-time 0)
   "Last time checked for events.")
 
+(defun org-wild-notifier--time= (&rest list)
+  "Compare timestamps.
+Comparison is performed by converted each element of LIST onto string
+in order to ignore seconds."
+  (->> list
+       (--map (format-time-string "%d:%H:%M" it))
+       (-uniq)
+       (length)
+       (= 1)))
+
 (defun org-wild-notifier--today ()
   "Get the timestamp for the beginning of current day."
   (apply 'encode-time


### PR DESCRIPTION
akhramov/org-wild-notifier.el#63 reverts some changes, but forgets to add back the `org-wild-notifier--time=` function. This commit simply adds back the function definition, exactly as it was in the commit before it was removed (166f394). Without this function, the package doesn't work at all (at least on a fresh install).