### PR TITLE
Pull in org-todo-keywords when retrieving events (#40) (#55)

### DIFF
--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -253,6 +253,7 @@ Returns a list of notification messages"
   (let ((agenda-files (-filter 'file-exists-p (org-agenda-files)))
         ;; Some package managers manipulate `load-path` variable.
         (my-load-path load-path)
+        (todo-keywords org-todo-keywords)
         (alert-time org-wild-notifier-alert-time)
         (keyword-whitelist org-wild-notifier-keyword-whitelist)
         (keyword-blacklist org-wild-notifier-keyword-blacklist)
@@ -263,6 +264,7 @@ Returns a list of notification messages"
             (org-agenda-compact-blocks t))
         (setf org-agenda-files agenda-files)
         (setf load-path my-load-path)
+        (setf org-todo-keywords todo-keywords)
         (setf org-wild-notifier-alert-time alert-time)
         (setf org-wild-notifier-keyword-whitelist keyword-whitelist)
         (setf org-wild-notifier-keyword-blacklist keyword-blacklist)


### PR DESCRIPTION
As advised at [#40](https://github.com/akhramov/org-wild-notifier.el/issues/40#issue-719845080), added `org-todo-keywords` to the variables pulled in for `org-wild-notifier--retrieve-events`. That issue [notes](https://github.com/akhramov/org-wild-notifier.el/issues/40#issuecomment-707478522) that `org-wild-notifier-alert-times-property` is also missing, but I didn't touch that; I don't use that property and am not convinced I would know whether it was working right.