### PR TITLE
Whitelist/blacklist by predicates

### DIFF
--- a/README.org
+++ b/README.org
@@ -22,19 +22,33 @@ be unobtrusive in use and configuration.
 
 Oh, yes. This package provides some configuration options:
 
-| Description                                                                                     | Variable                               | Default value               |
-|-------------------------------------------------------------------------------------------------+----------------------------------------+-----------------------------|
-| Alert time in minutes                                                                           | org-wild-notifier-alert-time           | '(10)                       |
-| Title of notifications                                                                          | org-wild-notifier-notification-title   | Agenda                      |
-| Notifications icon                                                                              | org-wild-notifier-notification-icon    | nil                         |
-| Org keyword based whitelist. You'll get notified /only/ about events specified by this variable | org-wild-notifier-keyword-whitelist    | '("TODO")                   |
-| Org keyword based blacklist. You'll /never/ be notified about events specified by this variable | org-wild-notifier-keyword-blacklist    | nil                         |
-| Org tags based whitelist. You'll get notified /only/ about events specified by this variable    | org-wild-notifier-tags-whitelist       | nil                         |
-| Org tags based blacklist. You'll /never/ be notified about events specified by this variable    | org-wild-notifier-tags-blacklist       | nil                         |
-| Property which adds additional notifications                                                    | org-wild-notifier-alert-times-property | WILD_NOTIFIER_NOTIFY_BEFORE |
+| Description                                                                                          | Variable                               | Default value               |
+|------------------------------------------------------------------------------------------------------+----------------------------------------+-----------------------------|
+| Alert time in minutes                                                                                | org-wild-notifier-alert-time           | '(10)                       |
+| Title of notifications                                                                               | org-wild-notifier-notification-title   | Agenda                      |
+| Notifications icon                                                                                   | org-wild-notifier-notification-icon    | nil                         |
+| Org keyword based whitelist. You'll get notified /only/ about events specified by this variable      | org-wild-notifier-keyword-whitelist    | '("TODO")                   |
+| Org keyword based blacklist. You'll /never/ be notified about events specified by this variable      | org-wild-notifier-keyword-blacklist    | nil                         |
+| Org tags based whitelist. You'll get notified /only/ about events specified by this variable         | org-wild-notifier-tags-whitelist       | nil                         |
+| Org tags based blacklist. You'll /never/ be notified about events specified by this variable         | org-wild-notifier-tags-blacklist       | nil                         |
+| Predicate based whitelist. You'll get notified /only/ about events matched by one of these functions | org-wild-notifier-predicate-whitelist  | nil                         |
+| Predicate based blacklist. You'll /never/ be notified about events matched by one of these functions | org-wild-notifier-predicate-blacklist  | nil                         |
+| Property which adds additional notifications                                                         | org-wild-notifier-alert-times-property | WILD_NOTIFIER_NOTIFY_BEFORE |
 
 
-The last property demands further explanations.
+~org-wild-notifier-predicate-whitelist~ and
+~org-wild-notifier-predicate-blacklist~ are lists of functions that take a
+single parameter, which is a marker on an Org event. For example, to not receive
+notifications for Org habits:
+
+#+BEGIN_SRC lisp
+  (setq org-wild-notifier-predicate-blacklist
+    '((lambda (marker)
+        (-contains? (org-entry-properties marker 'all)
+                    '("STYLE" . "habit")))))
+#+END_SRC
+
+~org-wild-notifier-alert-times-property~ demands further explanations.
 
 Let's suppose you have an important event. One standard 10-minute notification
 is not enough. Fear not, let's modify our Org entry.

--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -4,7 +4,7 @@
 
 ;; Author: Artem Khramov <akhramov+emacs@pm.me>
 ;; Created: 6 Jan 2017
-;; Version: 0.4.1
+;; Version: 0.5.0
 ;; Package-Requires: ((alert "1.2") (async "1.9.3") (dash "2.18.0") (emacs "24.4"))
 ;; Keywords: notification alert org org-agenda agenda
 ;; URL: https://github.com/akhramov/org-wild-notifier.el
@@ -106,6 +106,23 @@ Leave this variable blank if you do not want to filter anything."
   :package-version '(org-wild-notifier . "0.3.1")
   :group 'org-wild-notifier
   :type '(repeat string))
+
+(defcustom org-wild-notifier-predicate-whitelist nil
+  "Receive notifications for events matching these predicates only.
+Each function should take an event POM and return non-nil iff that event should
+trigger a notification. Leave this variable blank if you do not want to filter
+anything."
+  :package-version '(org-wild-notifier . "0.5.0")
+  :group 'org-wild-notifier
+  :type '(function))
+
+(defcustom org-wild-notifier-predicate-blacklist nil
+  "Never receive notifications for events matching these predicates.
+Each function should take an event POM and return non-nil iff that event should
+not trigger a notification."
+  :package-version '(org-wild-notifier . "0.5.0")
+  :group 'org-wild-notifier
+  :type '(function))
 
 (defcustom org-wild-notifier--alert-severity 'medium
   "Severity of the alert.
@@ -217,7 +234,11 @@ Returns a list of notification messages"
          [,org-wild-notifier-tags-whitelist
           (lambda (it)
             (-intersection org-wild-notifier-tags-whitelist
-                           (org-wild-notifier--get-tags it)))])
+                           (org-wild-notifier--get-tags it)))]
+
+         [,org-wild-notifier-predicate-whitelist
+          (lambda (marker)
+            (--some? (funcall it marker) org-wild-notifier-predicate-whitelist))])
        (--filter (aref it 0))
        (--map (aref it 1))))
 
@@ -230,7 +251,11 @@ Returns a list of notification messages"
          [,org-wild-notifier-tags-blacklist
           (lambda (it)
             (-intersection org-wild-notifier-tags-blacklist
-                           (org-wild-notifier--get-tags it)))])
+                           (org-wild-notifier--get-tags it)))]
+
+         [,org-wild-notifier-predicate-blacklist
+          (lambda (marker)
+            (--some? (funcall it marker) org-wild-notifier-predicate-blacklist))])
        (--filter (aref it 0))
        (--map (aref it 1))))
 
@@ -258,7 +283,9 @@ Returns a list of notification messages"
         (keyword-whitelist org-wild-notifier-keyword-whitelist)
         (keyword-blacklist org-wild-notifier-keyword-blacklist)
         (tags-whitelist org-wild-notifier-tags-whitelist)
-        (tags-blacklist org-wild-notifier-tags-blacklist))
+        (tags-blacklist org-wild-notifier-tags-blacklist)
+        (predicate-whitelist org-wild-notifier-predicate-whitelist)
+        (predicate-blacklist org-wild-notifier-predicate-blacklist))
     (lambda ()
       (let ((org-agenda-use-time-grid nil)
             (org-agenda-compact-blocks t))
@@ -270,6 +297,8 @@ Returns a list of notification messages"
         (setf org-wild-notifier-keyword-blacklist keyword-blacklist)
         (setf org-wild-notifier-tags-whitelist tags-whitelist)
         (setf org-wild-notifier-tags-blacklist tags-blacklist)
+        (setf org-wild-notifier-predicate-whitelist predicate-whitelist)
+        (setf org-wild-notifier-predicate-blacklist predicate-blacklist)
 
         (package-initialize)
         (require 'org-wild-notifier)


### PR DESCRIPTION
This adds the variables `org-wild-notifier-predicate-whitelist` and `org-wild-notifier-predicate-blacklist`, which behave similarly to the other whitelist/blacklist variables but check events against arbitrary predicate functions. This has been useful to me personally so I thought I'd propose it, but I'm troubled by a couple of things:
1. The predicate functions operate on markers. This could be considered leakage of an implementation detail - I don't think any marker-related APIs are exposed elsewhere.
2. The predicate functions are evaluated in the async callback context, which can be a footgun and arguably leaks another implementation detail.

If for those reasons (or any others) you don't want to accept the pull, that makes sense to me. Just wanted to throw the code out there. Cheers!