### PR TITLE
Add require org-duration and depend on emacs 26.1

### DIFF
--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -6,7 +6,7 @@
 ;; Author: Artem Khramov <akhramov+emacs@pm.me>
 ;; Created: 6 Jan 2017
 ;; Version: 0.5.0
-;; Package-Requires: ((alert "1.2") (async "1.9.3") (dash "2.18.0") (emacs "24.4"))
+;; Package-Requires: ((alert "1.2") (async "1.9.3") (dash "2.18.0") (emacs "26.1"))
 ;; Keywords: notification alert org org-agenda agenda
 ;; URL: https://github.com/akhramov/org-wild-notifier.el
 
@@ -48,6 +48,7 @@
 (require 'alert)
 (require 'async)
 (require 'org-agenda)
+(require 'org-duration)
 (require 'cl-lib)
 
 (defgroup org-wild-notifier nil


### PR DESCRIPTION
fixes error: Symbol’s function definition is void: org-duration-to-minutes