### PR TITLE
Prevent async process from prompting for passwords

### DIFF
--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -507,7 +507,8 @@ Do nothing if a check is already in progress in the background."
   (unless (and org-wild-notifier--process
                (process-live-p org-wild-notifier--process))
     (setq org-wild-notifier--process
-          (let ((default-directory user-emacs-directory))
+          (let ((default-directory user-emacs-directory)
+                (async-prompt-for-password nil))
             (async-start
              (org-wild-notifier--retrieve-events)
              'org-wild-notifier--check-events)))))


### PR DESCRIPTION
jwiegley/emacs-async#181 added a process filter to async.el which scans for any password prompts in the child process's output and prompts the user (used for async functions that need to authenticate over TRAMP, for example).

However, org-wild-notifier passes back an arbitrary large sexp from the child process which may accidentally match
tramp-password-prompt-regexp (in my case, the bracketed characters in "shop[pin]g list ... [:]").

To prevent this situation, disable async-prompt-for-password for processes started by org-wild-notifier.

(PR note: let-binding async-prompt-for-password doesn't work until jwiegley/emacs-async#182 is merged, but I expect that PR to be fairly uncontroversial.)