### PR TITLE
Don't prevent the user from killing emacs while a check is running

### DIFF
--- a/org-wild-notifier.el
+++ b/org-wild-notifier.el
@@ -510,7 +510,8 @@ Do nothing if a check is already in progress in the background."
           (let ((default-directory user-emacs-directory))
             (async-start
              (org-wild-notifier--retrieve-events)
-             'org-wild-notifier--check-events)))))
+             'org-wild-notifier--check-events)))
+    (set-process-query-on-exit-flag org-wild-notifier--process nil)))
 
 ;;;###autoload
 (define-minor-mode org-wild-notifier-mode


### PR DESCRIPTION
It's inconvenient to prompt the user whether they want to kill the asynchronous check process.  They almost certainly don't care if Emacs makes one last notification check, if they're already killing Emacs.  Besides, the process entry is just `emacs ... -f async-batch-invoke`, whose purpose is not super clear, so it's not obvious to the user whether it's safe to proceed.